### PR TITLE
permission deny 에러로 인한 CI/CD 문제 해결

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ secrets.AWS_PASSWORD }}
           port: 22
           script: |
-            sudo docker rm -f $(docker ps -qa)
+            sudo docker rm -f $(sudo docker ps -qa)
             sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/vote
             sudo docker run -d -p 8080:8080 --env-file .env ${{ secrets.DOCKER_USERNAME }}/vote


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

삭제할 컨테이너 ID를 가져올 때 `docker ps -qa` 대신 `sudo docker ps -qa` 를 사용하도록 변경

## 💬리뷰 참고사항

> 원활한 리뷰를 위해 전달하고 싶은 맥락(특정 파일, 디렉터리 등등)  
> 리뷰어가 특별히 봐주었으면 하는 부분

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #8 
